### PR TITLE
Возврат полного response при создании чека

### DIFF
--- a/cloudpayments/client.py
+++ b/cloudpayments/client.py
@@ -283,4 +283,4 @@ class CloudPayments(object):
 
         if not response['Success']:
             raise CloudPaymentsError(response)
-        return response['Message']
+        return response

--- a/cloudpayments/client.py
+++ b/cloudpayments/client.py
@@ -283,4 +283,4 @@ class CloudPayments(object):
 
         if not response['Success']:
             raise CloudPaymentsError(response)
-        return response
+        return response['Model']['Id']


### PR DESCRIPTION
При создании чека возвращается только сообщение, что поставлено в очередь, хотя логичнее для идентификации чека в дальнейших уведомлениях использовать ID чека, который приходит в этом же ответе.