### PR TITLE
Не явное исключение при ошибке авторизации

### DIFF
--- a/cloudpayments/client.py
+++ b/cloudpayments/client.py
@@ -24,6 +24,7 @@ class CloudPayments(object):
 
         response = requests.post(self.URL + endpoint, json=params, auth=auth, 
                                  headers=headers)
+        response.raise_for_status()
         return response.json(parse_float=decimal.Decimal)
 
     def test(self, request_id=None):


### PR DESCRIPTION
При ошибке авторизации возвращается html страница, которая не может быть распарсена в джсон, поэтому мы ловим requests.exceptions.JSONDecodeError и по началу не совсем понятно что это за ошибка и из-за чего она происходит.

А response.raise_for_status() будет выбрасывать вполне понятное исключение requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://api.cloudpayments.ru/test.